### PR TITLE
WIP for stream callbacks cleanup, will change sematics slightly so no

### DIFF
--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -289,6 +289,13 @@ public:
    * watermark to under its low watermark.
    */
   virtual void onBelowWriteBufferLowWatermark() PURE;
+
+  /**
+   * Fires when the codec level object is being closed.
+   * Any references to the stream or codec holding the stream
+   * should be removed. Otherwise they are dangling.
+   */
+  virtual void onCodecClose(Stream& stream) PURE;
 };
 
 /**

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -291,11 +291,13 @@ public:
   virtual void onBelowWriteBufferLowWatermark() PURE;
 
   /**
-   * Fires when the codec level object is being closed.
-   * Any references to the stream or codec holding the stream
-   * should be removed. Otherwise they are dangling.
+   * Fires when the codec level stream object is being closed.
+   * Any references to the stream or encoders holding the stream
+   * should be removed, otherwise they are dangling.
+   * No additional callbacks will fire for this event, as this
+   * is an implicit detach of all observers.
    */
-  virtual void onCodecClose(Stream& stream) PURE;
+  virtual void onCloseCodecStream() PURE;
 };
 
 /**

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -65,7 +65,10 @@ void CodecClient::connect() {
 void CodecClient::close() { connection_->close(Network::ConnectionCloseType::NoFlush); }
 
 void CodecClient::deleteRequest(ActiveRequest& request) {
-  request.cleanupEncoder();
+  if (request.encoder_) {
+    request.encoder_->getStream().removeCallbacks(request);
+    request.encoder_ = nullptr;
+  }
 
   connection_->dispatcher().deferredDelete(request.removeFromList(active_requests_));
   if (codec_client_callbacks_) {

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -226,16 +226,9 @@ private:
     }
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
-    void onCodecClose() override {
-      cleanupEncoder();
+    void onCloseCodecStream() override {
+      encoder_ = nullptr;
       // TODO(kbaichoo): Implement forwarding to the parent.
-    }
-
-    void cleanupEncoder() {
-      if (encoder_) {
-        encoder_->getStream().removeCallbacks(*this);
-        encoder_ = nullptr;
-      }
     }
 
     // StreamDecoderWrapper

--- a/source/common/http/codec_client.h
+++ b/source/common/http/codec_client.h
@@ -226,6 +226,17 @@ private:
     }
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
+    void onCodecClose() override {
+      cleanupEncoder();
+      // TODO(kbaichoo): Implement forwarding to the parent.
+    }
+
+    void cleanupEncoder() {
+      if (encoder_) {
+        encoder_->getStream().removeCallbacks(*this);
+        encoder_ = nullptr;
+      }
+    }
 
     // StreamDecoderWrapper
     void onPreDecodeComplete() override { parent_.responsePreDecodeComplete(*this); }

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -182,6 +182,7 @@ private:
                        absl::string_view transport_failure_reason) override;
     void onAboveWriteBufferHighWatermark() override;
     void onBelowWriteBufferLowWatermark() override;
+    void onCodecClose() override;
 
     // Http::StreamDecoder
     void decodeData(Buffer::Instance& data, bool end_stream) override;

--- a/source/common/http/conn_manager_impl.h
+++ b/source/common/http/conn_manager_impl.h
@@ -182,7 +182,7 @@ private:
                        absl::string_view transport_failure_reason) override;
     void onAboveWriteBufferHighWatermark() override;
     void onBelowWriteBufferLowWatermark() override;
-    void onCodecClose() override;
+    void onCloseCodecStream() override { response_encoder_ = nullptr; }
 
     // Http::StreamDecoder
     void decodeData(Buffer::Instance& data, bool end_stream) override;
@@ -367,6 +367,9 @@ private:
     Router::ConfigConstSharedPtr snapped_route_config_;
     Router::ScopedConfigConstSharedPtr snapped_scoped_routes_config_;
     Tracing::SpanPtr active_span_;
+    // Whether ResetAllStreams is invoked. This is good to know to avoid
+    // removing callbacks from the underlying stream twice.
+    bool reset_all_streams_{false};
     ResponseEncoder* response_encoder_{};
     Stats::TimespanPtr request_response_timespan_;
     // Per-stream idle timeout. This timer gets reset whenever activity occurs on the stream, and,

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -43,6 +43,8 @@ public:
     while (read_disable_calls_ != 0) {
       StreamEncoderImpl::readDisable(false);
     }
+
+    notifyObserversToDetach();
   }
   // Http::StreamEncoder
   void encodeData(Buffer::Instance& data, bool end_stream) override;

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -71,6 +71,11 @@ void ActiveClient::StreamWrapper::onResetStream(StreamResetReason, absl::string_
   parent_.codec_client_->close();
 }
 
+void ActiveClient::StreamWrapper::onCodecClose() {
+  // Remove as listener of the codecs callbacks.
+  ResponseEncoderWrapper::inner_.getStream().removeCallbacks(*this);
+}
+
 ActiveClient::ActiveClient(HttpConnPoolImplBase& parent)
     : Envoy::Http::ActiveClient(
           parent, parent.host()->cluster().maxRequestsPerConnection(),

--- a/source/common/http/http1/conn_pool.cc
+++ b/source/common/http/http1/conn_pool.cc
@@ -71,9 +71,9 @@ void ActiveClient::StreamWrapper::onResetStream(StreamResetReason, absl::string_
   parent_.codec_client_->close();
 }
 
-void ActiveClient::StreamWrapper::onCodecClose() {
-  // Remove as listener of the codecs callbacks.
-  ResponseEncoderWrapper::inner_.getStream().removeCallbacks(*this);
+void ActiveClient::StreamWrapper::onCloseCodecStream() {
+  // TODO(kbaichoo): turn ResponseEncoderWrapper::inner_ into nullptr or
+  // guard this somehow?
 }
 
 ActiveClient::ActiveClient(HttpConnPoolImplBase& parent)

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -57,7 +57,7 @@ public:
     void onResetStream(StreamResetReason, absl::string_view) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
-    void onCodecClose() override;
+    void onCloseCodecStream() override;
 
     ActiveClient& parent_;
     bool stream_incomplete_{};

--- a/source/common/http/http1/conn_pool.h
+++ b/source/common/http/http1/conn_pool.h
@@ -57,6 +57,7 @@ public:
     void onResetStream(StreamResetReason, absl::string_view) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
+    void onCodecClose() override;
 
     ActiveClient& parent_;
     bool stream_incomplete_{};

--- a/source/common/quic/envoy_quic_client_stream.cc
+++ b/source/common/quic/envoy_quic_client_stream.cc
@@ -288,8 +288,13 @@ void EnvoyQuicClientStream::maybeDecodeTrailers() {
 void EnvoyQuicClientStream::OnStreamReset(const quic::QuicRstStreamFrame& frame) {
   ENVOY_STREAM_LOG(debug, "received reset code={}", *this, frame.error_code);
   stats_.rx_reset_.inc();
-  quic::QuicSpdyClientStream::OnStreamReset(frame);
+  // TODO(kbaichoo): consult wth Dan on this. We end up destroying the codec
+  // level stream when we can into the quic OnStreamReset, but before we start
+  // invoking the runResetCallbacks. As such I think we'd want to invoke the
+  // onResetStreamCallbacks vs onCodecStreamClose which OnStreamReset will end
+  // up invoking.
   runResetCallbacks(quicRstErrorToEnvoyRemoteResetReason(frame.error_code));
+  quic::QuicSpdyClientStream::OnStreamReset(frame);
 }
 
 void EnvoyQuicClientStream::ResetWithError(quic::QuicResetStreamError error) {

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -314,7 +314,7 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
   }
 }
 
-void UpstreamRequest::onCodecClose() {
+void UpstreamRequest::onCloseCodecStream() {
   if (upstream_) {
     clearRequestEncoder();
   }

--- a/source/common/router/upstream_request.cc
+++ b/source/common/router/upstream_request.cc
@@ -314,6 +314,12 @@ void UpstreamRequest::onResetStream(Http::StreamResetReason reason,
   }
 }
 
+void UpstreamRequest::onCodecClose() {
+  if (upstream_) {
+    clearRequestEncoder();
+  }
+}
+
 void UpstreamRequest::resetStream() {
   // Don't reset the stream if we're already done with it.
   if (encode_complete_ && decode_complete_) {

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -64,6 +64,7 @@ public:
                      absl::string_view transport_failure_reason) override;
   void onAboveWriteBufferHighWatermark() override { disableDataFromDownstreamForFlowControl(); }
   void onBelowWriteBufferLowWatermark() override { enableDataFromDownstreamForFlowControl(); }
+  void onCodecClose() override;
   // UpstreamToDownstream
   const RouteEntry& routeEntry() const override;
   const Network::Connection& connection() const override;

--- a/source/common/router/upstream_request.h
+++ b/source/common/router/upstream_request.h
@@ -64,7 +64,7 @@ public:
                      absl::string_view transport_failure_reason) override;
   void onAboveWriteBufferHighWatermark() override { disableDataFromDownstreamForFlowControl(); }
   void onBelowWriteBufferLowWatermark() override { enableDataFromDownstreamForFlowControl(); }
-  void onCodecClose() override;
+  void onCloseCodecStream() override;
   // UpstreamToDownstream
   const RouteEntry& routeEntry() const override;
   const Network::Connection& connection() const override;

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -112,6 +112,13 @@ void HttpUpstream::onBelowWriteBufferLowWatermark() {
   upstream_callbacks_.onBelowWriteBufferLowWatermark();
 }
 
+void HttpUpstream::onCodecClose() {
+  if (request_encoder_) {
+    request_encoder_->getStream().removeCallbacks(*this);
+    request_encoder_ = nullptr;
+  }
+}
+
 void HttpUpstream::resetEncoder(Network::ConnectionEvent event, bool inform_downstream) {
   if (!request_encoder_) {
     return;

--- a/source/common/tcp_proxy/upstream.cc
+++ b/source/common/tcp_proxy/upstream.cc
@@ -112,13 +112,6 @@ void HttpUpstream::onBelowWriteBufferLowWatermark() {
   upstream_callbacks_.onBelowWriteBufferLowWatermark();
 }
 
-void HttpUpstream::onCodecClose() {
-  if (request_encoder_) {
-    request_encoder_->getStream().removeCallbacks(*this);
-    request_encoder_ = nullptr;
-  }
-}
-
 void HttpUpstream::resetEncoder(Network::ConnectionEvent event, bool inform_downstream) {
   if (!request_encoder_) {
     return;

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -143,6 +143,7 @@ public:
                      absl::string_view transport_failure_reason) override;
   void onAboveWriteBufferHighWatermark() override;
   void onBelowWriteBufferLowWatermark() override;
+  void onCodecClose() override;
 
   virtual void setRequestEncoder(Http::RequestEncoder& request_encoder, bool is_ssl) PURE;
   void setConnPoolCallbacks(std::unique_ptr<HttpConnPool::Callbacks>&& callbacks) {

--- a/source/common/tcp_proxy/upstream.h
+++ b/source/common/tcp_proxy/upstream.h
@@ -143,7 +143,7 @@ public:
                      absl::string_view transport_failure_reason) override;
   void onAboveWriteBufferHighWatermark() override;
   void onBelowWriteBufferLowWatermark() override;
-  void onCodecClose() override;
+  void onCloseCodecStream() override { request_encoder_ = nullptr; }
 
   virtual void setRequestEncoder(Http::RequestEncoder& request_encoder, bool is_ssl) PURE;
   void setConnPoolCallbacks(std::unique_ptr<HttpConnPool::Callbacks>&& callbacks) {

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -115,7 +115,7 @@ private:
                        absl::string_view transport_failure_reason) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
-    void onCodecClose() override { cleanupEncoder(); }
+    void onCloseCodecStream() override { cleanupEncoder(); }
 
     void cleanupEncoder();
     void onEvent(Network::ConnectionEvent event);
@@ -355,7 +355,7 @@ private:
                        absl::string_view transport_failure_reason) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
-    void onCodecClose() override { cleanupEncoder(); }
+    void onCloseCodecStream() override { cleanupEncoder(); }
 
     void cleanupEncoder();
     void onEvent(Network::ConnectionEvent event);

--- a/source/common/upstream/health_checker_impl.h
+++ b/source/common/upstream/health_checker_impl.h
@@ -115,7 +115,9 @@ private:
                        absl::string_view transport_failure_reason) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
+    void onCodecClose() override { cleanupEncoder(); }
 
+    void cleanupEncoder();
     void onEvent(Network::ConnectionEvent event);
     void onGoAway(Http::GoAwayErrorCode error_code);
 
@@ -145,13 +147,13 @@ private:
     HttpConnectionCallbackImpl http_connection_callback_impl_{*this};
     HttpHealthCheckerImpl& parent_;
     Http::CodecClientPtr client_;
+    Http::RequestEncoder* request_encoder_{nullptr};
     Http::ResponseHeaderMapPtr response_headers_;
     const std::string& hostname_;
     const Http::Protocol protocol_;
     Network::ConnectionInfoProviderSharedPtr local_connection_info_provider_;
     bool expect_reset_{};
     bool reuse_connection_ = false;
-    bool request_in_flight_ = false;
   };
 
   using HttpActiveHealthCheckSessionPtr = std::unique_ptr<HttpActiveHealthCheckSession>;
@@ -353,7 +355,9 @@ private:
                        absl::string_view transport_failure_reason) override;
     void onAboveWriteBufferHighWatermark() override {}
     void onBelowWriteBufferLowWatermark() override {}
+    void onCodecClose() override { cleanupEncoder(); }
 
+    void cleanupEncoder();
     void onEvent(Network::ConnectionEvent event);
     void onGoAway(Http::GoAwayErrorCode error_code);
 

--- a/source/extensions/upstreams/http/http/upstream_request.h
+++ b/source/extensions/upstreams/http/http/upstream_request.h
@@ -64,7 +64,7 @@ public:
 
   ~HttpUpstream() {
     if (request_encoder_) {
-      request_encoder_->getStream.removeCallbacks(*this);
+      request_encoder_->getStream().removeCallbacks(*this);
     }
   }
 
@@ -108,13 +108,10 @@ public:
     upstream_request_.onBelowWriteBufferLowWatermark();
   }
 
-  void onCodecClose() override {
-    if (request_encoder_) {
-      request_encoder_->getStream.removeCallbacks(*this);
-      // Forward information to the upstream request.
-      upstream_request_.onCodecClose();
-      request_encoder_ = nullptr;
-    }
+  void onCloseCodecStream() override {
+    // Forward information to the upstream request.
+    upstream_request_.onCloseCodecStream();
+    request_encoder_ = nullptr;
   }
 
 private:

--- a/test/common/http/codec_client_test.cc
+++ b/test/common/http/codec_client_test.cc
@@ -144,7 +144,7 @@ TEST_F(CodecClientTest, DisconnectBeforeHeaders) {
 
   Http::MockResponseDecoder outer_decoder;
   Http::StreamEncoder& request_encoder = client_->newStream(outer_decoder);
-  Http::MockStreamCallbacks callbacks;
+  Http::MockStreamCallbacks callbacks(request_encoder.getStream());
   request_encoder.getStream().addCallbacks(callbacks);
 
   // When we get a remote close with an active request we should try to send zero bytes through
@@ -167,7 +167,7 @@ TEST_F(CodecClientTest, IdleTimerWithNoActiveRequests) {
 
   Http::MockResponseDecoder outer_decoder;
   Http::StreamEncoder& request_encoder = client_->newStream(outer_decoder);
-  Http::MockStreamCallbacks callbacks;
+  Http::MockStreamCallbacks callbacks(request_encoder.getStream());
   request_encoder.getStream().addCallbacks(callbacks);
   connection_cb_->onEvent(Network::ConnectionEvent::Connected);
 
@@ -200,7 +200,7 @@ TEST_F(CodecClientTest, IdleTimerClientRemoteCloseWithActiveRequests) {
 
   Http::MockResponseDecoder outer_decoder;
   Http::StreamEncoder& request_encoder = client_->newStream(outer_decoder);
-  Http::MockStreamCallbacks callbacks;
+  Http::MockStreamCallbacks callbacks(request_encoder.getStream());
   request_encoder.getStream().addCallbacks(callbacks);
 
   // When we get a remote close with an active request validate idleTimer is reset after client
@@ -225,7 +225,7 @@ TEST_F(CodecClientTest, IdleTimerClientLocalCloseWithActiveRequests) {
 
   Http::MockResponseDecoder outer_decoder;
   Http::StreamEncoder& request_encoder = client_->newStream(outer_decoder);
-  Http::MockStreamCallbacks callbacks;
+  Http::MockStreamCallbacks callbacks(request_encoder.getStream());
   request_encoder.getStream().addCallbacks(callbacks);
 
   // When we get a local close with an active request validate idleTimer is reset after client close

--- a/test/common/http/http1/conn_pool_test.cc
+++ b/test/common/http/http1/conn_pool_test.cc
@@ -613,7 +613,7 @@ TEST_F(Http1ConnPoolImplTest, DisconnectWhileBound) {
   conn_pool_->test_clients_[0].connection_->raiseEvent(Network::ConnectionEvent::Connected);
 
   // We should get a reset callback when the connection disconnects.
-  Http::MockStreamCallbacks stream_callbacks;
+  Http::MockStreamCallbacks stream_callbacks(request_encoder.getStream());
   EXPECT_CALL(stream_callbacks, onResetStream(StreamResetReason::ConnectionTermination, _));
   request_encoder.getStream().addCallbacks(stream_callbacks);
 

--- a/test/common/router/router_2_test.cc
+++ b/test/common/router/router_2_test.cc
@@ -199,7 +199,7 @@ TEST_F(WatermarkTest, UpstreamWatermarks) {
                     .value());
 
   Buffer::OwnedImpl data;
-  EXPECT_CALL(encoder_, getStream()).Times(2).WillRepeatedly(ReturnRef(stream_));
+  EXPECT_CALL(encoder_, getStream()).Times(3).WillRepeatedly(ReturnRef(stream_));
   response_decoder_->decodeData(data, true);
 }
 

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -208,13 +208,6 @@ void FakeStream::onResetStream(Http::StreamResetReason, absl::string_view) {
   saw_reset_ = true;
 }
 
-void FakeStream::onCodecClose() {
-  if (encoder_) {
-    encoder_->getStream().removeCallbacks(*this);
-    encoder_ = nullptr;
-  }
-}
-
 AssertionResult FakeStream::waitForHeadersComplete(milliseconds timeout) {
   absl::MutexLock lock(&lock_);
   const auto reached = [this]()

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -227,7 +227,7 @@ public:
                      absl::string_view transport_failure_reason) override;
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
-  void onCodecClose() override;
+  void onCloseCodecStream() override { encoder_ = nullptr; }
 
   virtual void setEndStream(bool end) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) { end_stream_ = end; }
 

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -94,6 +94,7 @@ IntegrationCodecClient::makeHeaderOnlyRequest(const Http::RequestHeaderMap& head
   auto response = std::make_unique<IntegrationStreamDecoder>(dispatcher_);
   Http::RequestEncoder& encoder = newStream(*response);
   encoder.getStream().addCallbacks(*response);
+  response->setEncoder(&encoder);
   encoder.encodeHeaders(headers, true).IgnoreError();
   flushWrite();
   return response;
@@ -111,6 +112,7 @@ IntegrationCodecClient::makeRequestWithBody(const Http::RequestHeaderMap& header
   auto response = std::make_unique<IntegrationStreamDecoder>(dispatcher_);
   Http::RequestEncoder& encoder = newStream(*response);
   encoder.getStream().addCallbacks(*response);
+  response->setEncoder(&encoder);
   encoder.encodeHeaders(headers, false).IgnoreError();
   Buffer::OwnedImpl data(body);
   encoder.encodeData(data, true);
@@ -162,6 +164,7 @@ IntegrationCodecClient::startRequest(const Http::RequestHeaderMap& headers) {
   auto response = std::make_unique<IntegrationStreamDecoder>(dispatcher_);
   Http::RequestEncoder& encoder = newStream(*response);
   encoder.getStream().addCallbacks(*response);
+  response->setEncoder(&encoder);
   encoder.encodeHeaders(headers, false).IgnoreError();
   flushWrite();
   return {encoder, std::move(response)};

--- a/test/integration/integration_stream_decoder.cc
+++ b/test/integration/integration_stream_decoder.cc
@@ -145,11 +145,4 @@ void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason reason, abs
   }
 }
 
-void IntegrationStreamDecoder::onCodecClose() {
-  if (encoder_) {
-    encoder_->getStream().removeCallbacks(*this);
-    encoder_ = nullptr;
-  }
-}
-
 } // namespace Envoy

--- a/test/integration/integration_stream_decoder.cc
+++ b/test/integration/integration_stream_decoder.cc
@@ -24,6 +24,12 @@ namespace Envoy {
 IntegrationStreamDecoder::IntegrationStreamDecoder(Event::Dispatcher& dispatcher)
     : dispatcher_(dispatcher) {}
 
+IntegrationStreamDecoder::~IntegrationStreamDecoder() {
+  if (encoder_) {
+    encoder_->getStream().removeCallbacks(*this);
+  }
+}
+
 void IntegrationStreamDecoder::waitForContinueHeaders() {
   if (!continue_headers_.get()) {
     waiting_for_continue_headers_ = true;
@@ -136,6 +142,13 @@ void IntegrationStreamDecoder::onResetStream(Http::StreamResetReason reason, abs
   reset_reason_ = reason;
   if (waiting_for_reset_) {
     dispatcher_.exit();
+  }
+}
+
+void IntegrationStreamDecoder::onCodecClose() {
+  if (encoder_) {
+    encoder_->getStream().removeCallbacks(*this);
+    encoder_ = nullptr;
   }
 }
 

--- a/test/integration/integration_stream_decoder.h
+++ b/test/integration/integration_stream_decoder.h
@@ -70,7 +70,7 @@ public:
                      absl::string_view transport_failure_reason) override;
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
-  void onCodecClose() override;
+  void onCloseCodecStream() override { encoder_ = nullptr; }
 
 private:
   Event::Dispatcher& dispatcher_;

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -159,7 +159,7 @@ sendRequestAndWaitForResponse(Event::Dispatcher& dispatcher, const std::string& 
 
   Http::RequestEncoder& encoder = client.newStream(*response);
   encoder.getStream().addCallbacks(*response);
-  response->setEncoder(encoder);
+  response->setEncoder(&encoder);
 
   Http::TestRequestHeaderMapImpl headers;
   headers.setMethod(method);

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -152,12 +152,14 @@ sendRequestAndWaitForResponse(Event::Dispatcher& dispatcher, const std::string& 
                               const std::string& url, const std::string& body,
                               const std::string& host, const std::string& content_type,
                               Http::CodecClientProd& client) {
-  BufferingStreamDecoderPtr response(new BufferingStreamDecoder([&]() -> void {
+  BufferingStreamDecoderPtr response = std::make_unique<BufferingStreamDecoder>([&]() -> void {
     client.close();
     dispatcher.exit();
-  }));
+  });
+
   Http::RequestEncoder& encoder = client.newStream(*response);
   encoder.getStream().addCallbacks(*response);
+  response->setEncoder(encoder);
 
   Http::TestRequestHeaderMapImpl headers;
   headers.setMethod(method);

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -135,6 +135,7 @@ public:
   MOCK_METHOD(void, onResetStream, (StreamResetReason reason, absl::string_view));
   MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
+  MOCK_METHOD(void, onCodecClose, (Stream&));
 };
 
 class MockServerConnection : public ServerConnection {

--- a/test/mocks/http/mocks.h
+++ b/test/mocks/http/mocks.h
@@ -129,13 +129,18 @@ public:
 class MockStreamCallbacks : public StreamCallbacks {
 public:
   MockStreamCallbacks();
+  MockStreamCallbacks(Http::Stream& stream);
   ~MockStreamCallbacks() override;
 
   // Http::StreamCallbacks
   MOCK_METHOD(void, onResetStream, (StreamResetReason reason, absl::string_view));
   MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
-  MOCK_METHOD(void, onCodecClose, (Stream&));
+  MOCK_METHOD(void, onCloseCodecStream, ());
+
+  void setStream(Http::Stream& stream);
+
+  Http::Stream* stream_{nullptr};
 };
 
 class MockServerConnection : public ServerConnection {

--- a/test/mocks/http/stream.cc
+++ b/test/mocks/http/stream.cc
@@ -9,17 +9,34 @@ namespace Http {
 
 MockStream::MockStream() {
   ON_CALL(*this, addCallbacks(_)).WillByDefault(Invoke([this](StreamCallbacks& callbacks) -> void {
+    std::cerr << "Adding callback: " << &callbacks << " on stream:" << this << std::endl;
     callbacks_.push_back(&callbacks);
   }));
 
   ON_CALL(*this, removeCallbacks(_))
-      .WillByDefault(
-          Invoke([this](StreamCallbacks& callbacks) -> void { callbacks_.remove(&callbacks); }));
+      .WillByDefault(Invoke([this](StreamCallbacks& callbacks) -> void {
+        std::cerr << "Removing callback: " << &callbacks << " on stream: " << this << std::endl;
+        for (auto& callback : callbacks_) {
+          if (callback == &callbacks) {
+            callback = nullptr;
+            return;
+          }
+        }
+      }));
 
   ON_CALL(*this, resetStream(_)).WillByDefault(Invoke([this](StreamResetReason reason) -> void {
-    for (StreamCallbacks* callbacks : callbacks_) {
-      callbacks->onResetStream(reason, absl::string_view());
+    std::cerr << "Mock Reset Stream has " << callbacks_.size() << " items on stream:" << this
+              << std::endl;
+    for (StreamCallbacks* callback : callbacks_) {
+      // TODO(kbaichoo): do I need this?? Might not.
+      std::cerr << "Callback: " << callback << std::endl;
+      if (callback) {
+        callback->onResetStream(reason, absl::string_view());
+      }
+      std::cerr << "Ran Callback: " << callback << std::endl;
     }
+
+    callbacks_.clear();
   }));
 
   ON_CALL(*this, connectionLocalAddress()).WillByDefault(ReturnRef(connection_local_address_));
@@ -33,6 +50,17 @@ MockStream::~MockStream() {
   if (account_) {
     account_->clearDownstream();
   }
+
+  std::cerr << "~MockStream: " << this << std::endl;
+  for (StreamCallbacks* callback : callbacks_) {
+    std::cerr << "Callback: " << callback << std::endl;
+    if (callback) {
+      callback->onCloseCodecStream();
+    }
+    std::cerr << "Ran Callback: " << callback << std::endl;
+  }
+
+  callbacks_.clear();
 }
 
 } // namespace Http

--- a/test/mocks/http/stream.h
+++ b/test/mocks/http/stream.h
@@ -23,19 +23,24 @@ public:
   MOCK_METHOD(void, setFlushTimeout, (std::chrono::milliseconds timeout));
   MOCK_METHOD(void, setAccount, (Buffer::BufferMemoryAccountSharedPtr));
 
-  std::list<StreamCallbacks*> callbacks_{};
+  // Use same underlying structure e.g. to insure iteration stability.
+  absl::InlinedVector<StreamCallbacks*, 8> callbacks_;
   Network::Address::InstanceConstSharedPtr connection_local_address_;
   Buffer::BufferMemoryAccountSharedPtr account_;
 
   void runHighWatermarkCallbacks() {
     for (auto* callback : callbacks_) {
-      callback->onAboveWriteBufferHighWatermark();
+      if (callback) {
+        callback->onAboveWriteBufferHighWatermark();
+      }
     }
   }
 
   void runLowWatermarkCallbacks() {
     for (auto* callback : callbacks_) {
-      callback->onBelowWriteBufferLowWatermark();
+      if (callback) {
+        callback->onBelowWriteBufferLowWatermark();
+      }
     }
   }
 };

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -581,7 +581,7 @@ public:
   MOCK_METHOD(void, onResetStream, (Http::StreamResetReason, absl::string_view));
   MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
-  MOCK_METHOD(void, onCodecClose, (Stream&));
+  MOCK_METHOD(void, onCloseCodecStream, ());
 };
 
 class MockGenericConnectionPoolCallbacks : public GenericConnectionPoolCallbacks {

--- a/test/mocks/router/mocks.h
+++ b/test/mocks/router/mocks.h
@@ -581,6 +581,7 @@ public:
   MOCK_METHOD(void, onResetStream, (Http::StreamResetReason, absl::string_view));
   MOCK_METHOD(void, onAboveWriteBufferHighWatermark, ());
   MOCK_METHOD(void, onBelowWriteBufferLowWatermark, ());
+  MOCK_METHOD(void, onCodecClose, (Stream&));
 };
 
 class MockGenericConnectionPoolCallbacks : public GenericConnectionPoolCallbacks {


### PR DESCRIPTION
need to assert empty on dtor of streamcallbackhelper and do implicit
disconnect.

Signed-off-by: Kevin Baichoo <kbaichoo@google.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
